### PR TITLE
kc-viewer: remove agility display in wilderness agility course (fixes #12/#13)

### DIFF
--- a/src/main/java/com/killcountviewer/KillCountViewerService.java
+++ b/src/main/java/com/killcountviewer/KillCountViewerService.java
@@ -561,8 +561,6 @@ class KillCountViewerService
 				isInArea(player, 3471, 3509, 3517, 3467, 3) ||
 				// Agility Pyramid
 				isInArea(player, 2690, 3466, 2703, 3459, -1) ||
-				// Wilderness Agility Course
-				isInArea(player, 2988, 3966, 3009, 3913) ||
 				// Colossal Wyrm Agility Course
 				isInArea(player, 1622, 2935, 1657, 2903, -1) ||
 				// Ape Atoll Agility Course


### PR DESCRIPTION
This plugin was disabled a few weeks ago because of a supposed advantage of scouting player's agility level in the wilderness¹. This PR removes that functionality so it can be brought back into the hub.

¹ While I think that's been blown out of proportion since it only does that inside the WIlderness Agility Course and the nearest shortcut is over 200 tiles away, don't think there's much point arguing it.